### PR TITLE
Add mutable default argument detection to bad practices heuristic

### DIFF
--- a/core/analyzer.py
+++ b/core/analyzer.py
@@ -118,7 +118,18 @@ class CodeAnalyzer:
                     imports.extend(alias.name for alias in node.names)
             if len(set(imports)) != len(imports):
                 findings.append("Duplicate imports detected.")
-
+        # 5. Check for mutable default arguments (e.g. def func(x=[]) or def func(x={}))
+        if self.tree:
+            for node in ast.walk(self.tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    for default in node.args.defaults:
+                        if isinstance(default, (ast.List, ast.Dict, ast.Set)):
+                            findings.append(
+                        f"Mutable default argument in function "
+                        f"'{node.name}': use None as default instead."
+                    )
+                    break # one finding per function is enough
+    
         return findings
 
     def get_docstring_coverage(self):

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -133,6 +133,21 @@ class TestDetectBadPractices:
         analyzer = CodeAnalyzer(SIMPLE_CODE)
         findings = analyzer.detect_bad_practices()
         assert findings == []
+    def test_detects_mutable_default_list(self):
+        code = "def process(items=[]):\n    return items"
+        analyzer = CodeAnalyzer(code)
+        findings = analyzer.detect_bad_practices()
+        assert any("mutable default" in f.lower() for f in findings)
+    def test_detects_mutable_default_dict(self):
+        code = "def fibonacci(n, memo={}):\n    return memo.get(n, n)"
+        analyzer = CodeAnalyzer(code)
+        findings = analyzer.detect_bad_practices()
+        assert any("mutable default" in f.lower() for f in findings)
+    def test_clean_function_no_mutable_default(self):
+            code = "def fibonacci(n, memo=None):\n    return n"
+            analyzer = CodeAnalyzer(code)
+            findings = analyzer.detect_bad_practices()
+            assert not any("mutable default" in f.lower() for f in findings)
 
 
 # --- Docstring Coverage Tests ---


### PR DESCRIPTION
## Problem
The `detect_bad_practices()` method in `core/analyzer.py` did not 
detect mutable default arguments — a well-known Python anti-pattern 
where a mutable object (list, dict, or set) is used as a function 
parameter default value.

This pattern was present in:
- `datasets/llama_3_3_70b_versatile/task-005.py` — `def fibonacci(n, memo={})`
- `datasets/ai_samples/claude/TASK-005_claude.py` — `def fibonacci_memoized(n, memo={})`

Both files experienced runtime errors in the benchmark, which this 
heuristic would have surfaced earlier.

## Solution
Added a new check (#5) to `detect_bad_practices()` that walks the AST 
looking for `FunctionDef` and `AsyncFunctionDef` nodes whose 
`args.defaults` contain `ast.List`, `ast.Dict`, or `ast.Set` nodes.

The finding message includes the function name for actionability.

## Testing
Three new test cases added and passing:
- `test_detects_mutable_default_list`
- `test_detects_mutable_default_dict`
- `test_clean_function_no_mutable_default` (no false positive for memo=None)

All existing tests continue to pass.


Closes #45 