### PR TITLE
Add --compare flag for benchmark run-to-run comparison

### DIFF
--- a/core/reporter.py
+++ b/core/reporter.py
@@ -214,7 +214,7 @@ class VibeReporter:
             md += f"## {label} Comparisons\n\n"
             md += (
                 "| Model A | Model B | U Statistic | p-value | Significant |\n"
-                )
+            )
             md += "| :--- | :--- | :---: | :---: | :---: |\n"
 
             results = self.compare_models_statistically(metric)
@@ -287,7 +287,7 @@ class VibeReporter:
                     models[m]['comp'].append(comp)
                 exec_t = entry.get('execution_time_sec')
                 if isinstance(exec_t, (int, float)):
-                        models[m]['time'].append(exec_t)
+                    models[m]['time'].append(exec_t)
             # Compute averages
             for m in models:
                 models[m]['avg_comp'] = (
@@ -305,8 +305,6 @@ class VibeReporter:
             return models
         stats_a = aggregate(data_a)
         stats_b = aggregate(data_b)
-
-        all_models = set(stats_a.keys()) | set(stats_b.keys())
         added = set(stats_b.keys()) - set(stats_a.keys())
         dropped = set(stats_a.keys()) - set(stats_b.keys())
         common = set(stats_a.keys()) & set(stats_b.keys())
@@ -365,8 +363,7 @@ class VibeReporter:
                     else "—"
                 )
             else:
-                delta_comp_str ={
-                    "N/A"}
+                delta_comp_str = "N/A"
 
             time_a = f"{a['avg_time']}s" if a['avg_time'] is not None else "N/A"
             time_b = f"{b['avg_time']}s" if b['avg_time'] is not None else "N/A"

--- a/core/reporter.py
+++ b/core/reporter.py
@@ -212,7 +212,9 @@ class VibeReporter:
             ('complexity', 'Cyclomatic Complexity')
         ]:
             md += f"## {label} Comparisons\n\n"
-            md += "| Model A | Model B | U Statistic | p-value | Significant |\n"
+            md += (
+                "| Model A | Model B | U Statistic | p-value | Significant |\n"
+                )
             md += "| :--- | :--- | :---: | :---: | :---: |\n"
 
             results = self.compare_models_statistically(metric)
@@ -239,6 +241,184 @@ class VibeReporter:
         with open(output_file, 'w', encoding='utf-8') as f:
             f.write(md)
         print(f"✅ Significance report generated: {output_file}")
+
+    @staticmethod
+    def compare_runs(json_file_a, json_file_b, output_file="VibeBench_Comparison.md"):
+        """
+        Compares two benchmark JSON files and produces a regression/
+        improvement report showing how model performance changed between runs.
+
+        Models present in only one run are flagged as added or dropped.
+        For models present in both runs, changes in success rate, average
+        complexity, and average execution time are reported.
+        Args:
+            json_file_a (str): Path to the earlier benchmark JSON file
+                (baseline run).
+            json_file_b (str): Path to the later benchmark JSON file
+                (comparison run).
+            output_file (str): Path to write the Markdown comparison report.
+        Returns:
+            dict: Summary of changes keyed by model name.
+        """
+        for path in (json_file_a, json_file_b):
+            if not os.path.exists(path):
+                raise FileNotFoundError(f"Benchmark file not found: {path}")
+        with open(json_file_a, 'r', encoding='utf-8') as f:
+            data_a = json.load(f)
+        with open(json_file_b, 'r', encoding='utf-8') as f:
+            data_b = json.load(f)
+
+        def aggregate(data):
+
+            """Aggregate benchmark records by model into summary stats."""
+            models = {}
+            for entry in data:
+                m = entry.get('model', 'Unknown')
+                if m not in models:
+                    models[m] = {
+                        'success': 0, 'total': 0,
+                        'comp': [], 'time': []
+                    }
+                models[m]['total'] += 1
+                if entry.get('status') == 'Success':
+                    models[m]['success'] += 1
+                comp = entry.get('complexity')
+                if isinstance(comp, (int, float)):
+                    models[m]['comp'].append(comp)
+                exec_t = entry.get('execution_time_sec')
+                if isinstance(exec_t, (int, float)):
+                        models[m]['time'].append(exec_t)
+            # Compute averages
+            for m in models:
+                models[m]['avg_comp'] = (
+                    round(sum(models[m]['comp']) / len(models[m]['comp']), 2)
+                    if models[m]['comp'] else None
+                )
+                models[m]['avg_time'] = (
+                    round(sum(models[m]['time']) / len(models[m]['time']), 4)
+                    if models[m]['time'] else None
+                )
+                models[m]['success_rate'] = (
+                    models[m]['success'] / models[m]['total']
+                    if models[m]['total'] > 0 else 0
+                )
+            return models
+        stats_a = aggregate(data_a)
+        stats_b = aggregate(data_b)
+
+        all_models = set(stats_a.keys()) | set(stats_b.keys())
+        added = set(stats_b.keys()) - set(stats_a.keys())
+        dropped = set(stats_a.keys()) - set(stats_b.keys())
+        common = set(stats_a.keys()) & set(stats_b.keys())
+
+        # Build Markdown report
+        md = "# VibeBench Run Comparison Report\n\n"
+        md += f"**Run A:** `{os.path.basename(json_file_a)}`\n"
+        md += f"**Run B:** `{os.path.basename(json_file_b)}`\n"
+        md += f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M')}\n\n"
+
+        # Models added or dropped
+        if added:
+            md += "## ✅ Models Added in Run B\n\n"
+            for m in sorted(added):
+                md += f"- `{m.upper()}`\n"
+            md += "\n"
+        if dropped:
+            md += "## ❌ Models Dropped from Run A\n\n"
+            for m in sorted(dropped):
+                md += f"- `{m.upper()}`\n"
+            md += "\n"
+        # Side-by-side comparison for common models
+        md += "## 📊 Model Performance Changes\n\n"
+        md += (
+            "| Model | Success A | Success B | Δ Success | "
+            "Avg Complexity A | Avg Complexity B | Δ Complexity | "
+            "Avg Exec Time A | Avg Exec Time B | Δ Exec Time |\n"
+        )
+        md += (
+            "| :--- | :---: | :---: | :---: | "
+            ":---: | :---: | :---: | "
+            ":---: | :---: | :---: |\n"
+        )
+
+        changes = {}
+        for m in sorted(common):
+            a = stats_a[m]
+            b = stats_b[m]
+
+            sr_a = f"{a['success']}/{a['total']}"
+            sr_b = f"{b['success']}/{b['total']}"
+            delta_sr = b['success_rate'] - a['success_rate']
+            delta_sr_str = (
+                f"+{delta_sr:.0%}" if delta_sr > 0
+                else f"{delta_sr:.0%}" if delta_sr < 0
+                else "—"
+            )
+
+            comp_a = a['avg_comp'] if a['avg_comp'] is not None else "N/A"
+            comp_b = b['avg_comp'] if b['avg_comp'] is not None else "N/A"
+            if isinstance(comp_a, float) and isinstance(comp_b, float):
+                delta_comp = round(comp_b - comp_a, 2)
+                delta_comp_str = (
+                    f"+{delta_comp}" if delta_comp > 0
+                    else str(delta_comp) if delta_comp < 0
+                    else "—"
+                )
+            else:
+                delta_comp_str ={
+                    "N/A"}
+
+            time_a = f"{a['avg_time']}s" if a['avg_time'] is not None else "N/A"
+            time_b = f"{b['avg_time']}s" if b['avg_time'] is not None else "N/A"
+            if a['avg_time'] is not None and b['avg_time'] is not None:
+                delta_time = round(b['avg_time'] - a['avg_time'], 4)
+                delta_time_str = (
+                    f"+{delta_time}s" if delta_time > 0
+                    else f"{delta_time}s" if delta_time < 0
+                    else "—"
+                )
+            else:
+                delta_time_str = "N/A"
+
+            md += (
+                f"| {m.upper()} | {sr_a} | {sr_b} | {delta_sr_str} | "
+                f"{comp_a} | {comp_b} | {delta_comp_str} | "
+                f"{time_a} | {time_b} | {delta_time_str} |\n"
+            )
+
+            changes[m] = {
+                'delta_success_rate': delta_sr,
+                'delta_complexity': (
+                    round(comp_b - comp_a, 2)
+                    if isinstance(comp_a, float) and isinstance(comp_b, float)
+                    else None
+                ),
+                'delta_exec_time': (
+                    round(b['avg_time'] - a['avg_time'], 4)
+                    if a['avg_time'] and b['avg_time'] else None
+                )
+            }
+        # Summary
+        regressions = [
+            m for m, c in changes.items() if c['delta_success_rate'] < 0
+        ]
+        improvements = [
+            m for m, c in changes.items() if c['delta_success_rate'] > 0
+        ]
+
+        md += "\n## 📋 Summary\n\n"
+        if improvements:
+            md += f"**Improved:** {', '.join(m.upper() for m in improvements)}\n\n"
+        if regressions:
+            md += f"**Regressed:** {', '.join(m.upper() for m in regressions)}\n\n"
+        if not improvements and not regressions:
+            md += "No success rate changes detected between runs.\n\n"
+
+        with open(output_file, 'w', encoding='utf-8') as f:
+            f.write(md)
+
+        print(f"✅ Comparison report generated: {output_file}")
+        return changes
 
 
 if __name__ == "__main__":

--- a/preprint/README.md
+++ b/preprint/README.md
@@ -38,3 +38,15 @@ in progress before arXiv submission.
 | 6. Limitations | ✅ Complete |
 | 7. Conclusion | ✅ Complete |
 | References | ✅ Complete |
+
+### Generate reports from existing benchmark data
+
+```bash
+# Regenerate the leaderboard without re-running the benchmark
+vibebench report --input vibebench_multimodel_YYYYMMDD_HHMM.json --leaderboard
+
+# Generate statistical significance report
+vibebench report --input vibebench_multimodel_YYYYMMDD_HHMM.json --significance
+
+# Compare two benchmark runs for regressions and improvements
+vibebench report --compare run1.json run2.json

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -10,6 +10,52 @@ from core.reporter import VibeReporter
 
 # --- Fixtures ---
 
+@pytest.fixture
+def sample_json_path(tmp_path):
+    """Creates a minimal benchmark JSON file for testing."""
+    data = [
+        {
+            "model": "chatgpt", "file": "TASK-001.py",
+            "complexity": 2.0, "docstring_coverage": 100.0,
+            "bad_practices_count": 0, "execution_time_sec": 0.05,
+            "status": "Success"
+        },
+        {
+            "model": "chatgpt", "file": "TASK-002.py",
+            "complexity": 4.0, "docstring_coverage": 50.0,
+            "bad_practices_count": 1, "execution_time_sec": 0.12,
+            "status": "Runtime Error"
+        },
+        {
+            "model": "claude", "file": "TASK-001.py",
+            "complexity": 3.0, "docstring_coverage": 0.0,
+            "bad_practices_count": 0, "execution_time_sec": 0.06,
+            "status": "Success"
+        },
+        {
+            "model": "claude", "file": "TASK-002.py",
+            "complexity": 5.0, "docstring_coverage": 0.0,
+            "bad_practices_count": 0, "execution_time_sec": 0.09,
+            "status": "Success"
+        },
+        {
+            "model": "human_samples", "file": "TASK-001.py",
+            "complexity": 1.0, "docstring_coverage": 100.0,
+            "bad_practices_count": 0, "execution_time_sec": 0.04,
+            "status": "Success"
+        },
+        {
+            "model": "human_samples", "file": "TASK-002.py",
+            "complexity": 2.0, "docstring_coverage": 0.0,
+            "bad_practices_count": 0, "execution_time_sec": 0.05,
+            "status": "Success"
+        },
+    ]
+    path = str(tmp_path / "sample_benchmark.json")
+    with open(path, 'w') as f:
+        json.dump(data, f)
+    return path
+
 SAMPLE_DATA = [
     {
         "model": "chatgpt",
@@ -207,3 +253,58 @@ class TestStatisticalTesting:
         assert "Execution Time" in content
         assert "Cyclomatic Complexity" in content
         assert "p-value" in content
+
+class TestCompareRuns:
+
+    def test_compare_runs_produces_file(self, tmp_path, sample_json_path):
+        """compare_runs should create the output markdown file."""
+        output = str(tmp_path / "comparison.md")
+        # Compare file against itself — valid edge case
+        VibeReporter.compare_runs(
+            sample_json_path, sample_json_path,
+            output_file=output
+        )
+        assert os.path.exists(output)
+
+    def test_compare_runs_returns_dict(self, tmp_path, sample_json_path):
+        """compare_runs should return a dict of model changes."""
+        output = str(tmp_path / "comparison.md")
+        result = VibeReporter.compare_runs(
+            sample_json_path, sample_json_path,
+            output_file=output
+        )
+        assert isinstance(result, dict)
+
+    def test_compare_runs_contains_model_section(
+        self, tmp_path, sample_json_path
+    ):
+        """Output file should contain the performance changes table."""
+        output = str(tmp_path / "comparison.md")
+        VibeReporter.compare_runs(
+            sample_json_path, sample_json_path,
+            output_file=output
+        )
+        with open(output) as f:
+            content = f.read()
+        assert "Model Performance Changes" in content
+
+    def test_compare_runs_missing_file_raises(self, tmp_path, sample_json_path):
+        """compare_runs should raise FileNotFoundError for missing files."""
+        import pytest
+        output = str(tmp_path / "comparison.md")
+        with pytest.raises(FileNotFoundError):
+            VibeReporter.compare_runs(
+                "nonexistent_file.json", sample_json_path,
+                output_file=output
+            )
+
+    def test_same_file_shows_no_changes(self, tmp_path, sample_json_path):
+        """Comparing a file against itself should show no success rate changes."""
+        output = str(tmp_path / "comparison.md")
+        changes = VibeReporter.compare_runs(
+            sample_json_path, sample_json_path,
+            output_file=output
+        )
+        for model, delta in changes.items():
+            assert delta['delta_success_rate'] == 0.0
+

--- a/vibebench.py
+++ b/vibebench.py
@@ -279,14 +279,6 @@ def main():
         )
     )
 
-    if args.leaderboard or args.significance:
-        if not args.input:
-            print(
-                "❌ --input is required when using "
-                "--leaderboard or --significance."
-                )
-            return
-
     # --- benchmark command ---
     benchmark_parser = subparsers.add_parser(
         "benchmark",
@@ -374,6 +366,13 @@ def main():
                 "⚠️  No report type specified. "
                 "Use --leaderboard, --significance, or --compare FILE_A FILE_B."
             )
+        if args.leaderboard or args.significance:
+            if not args.input:
+                print(
+                    "❌ --input is required when using "
+                    "--leaderboard or --significance."
+                    )
+                return
 
 
 if __name__ == "__main__":

--- a/vibebench.py
+++ b/vibebench.py
@@ -371,7 +371,7 @@ def main():
                 print(
                     "❌ --input is required when using "
                     "--leaderboard or --significance."
-                    )
+                )
                 return
 
 

--- a/vibebench.py
+++ b/vibebench.py
@@ -42,7 +42,7 @@ class VibeBench:
 
         Returns:
             float: The average complexity of all code blocks, rounded to two
-                   decimal places. Returns None on error.
+                decimal places. Returns None on error.
         """
         try:
             blocks = cc_visit(code)
@@ -246,7 +246,7 @@ def main():
     )
     report_parser.add_argument(
         "--input",
-        required=True,
+        required=False,
         metavar="FILE",
         help="Path to a benchmark JSON file."
     )
@@ -268,6 +268,24 @@ def main():
         default=".",
         help="Directory to write report files (default: current directory)."
     )
+    report_parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("FILE_A", "FILE_B"),
+        default=None,
+        help=(
+            "Compare two benchmark JSON files and report regressions "
+            "and improvements. Usage: --compare run1.json run2.json"
+        )
+    )
+
+    if args.leaderboard or args.significance:
+        if not args.input:
+            print(
+                "❌ --input is required when using "
+                "--leaderboard or --significance."
+                )
+            return
 
     # --- benchmark command ---
     benchmark_parser = subparsers.add_parser(
@@ -334,6 +352,13 @@ def main():
         bench.run_benchmark(export_csv=args.export_csv)
     elif args.command == "report":
         reporter = VibeReporter(args.input)
+        if args.compare:
+            file_a, file_b = args.compare
+            output_path = os.path.join(
+                args.output_dir, "VibeBench_Comparison.md"
+            )
+            VibeReporter.compare_runs(file_a, file_b, output_file=output_path)
+
         if args.leaderboard:
             output_path = os.path.join(
                 args.output_dir, "VibeBench_Leaderboard.md"
@@ -344,6 +369,11 @@ def main():
                 args.output_dir, "VibeBench_Significance_Report.md"
             )
             reporter.generate_significance_report(output_file=output_path)
+        if not args.leaderboard and not args.significance and not args.compare:
+            print(
+                "⚠️  No report type specified. "
+                "Use --leaderboard, --significance, or --compare FILE_A FILE_B."
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this adds

A new --compare flag on the report subcommand that takes two
benchmark JSON files and produces a regression/improvement report.

## Usage

```bash
vibebench report --compare run1.json run2.json
```

## Output: VibeBench_Comparison.md
- Lists models added or dropped between runs
- Side-by-side table: success rate, complexity, exec time with deltas
- Summary section calling out regressions and improvements

## Why this matters
Makes VibeBench useful for longitudinal tracking — e.g. comparing
benchmark results before and after a model update, or tracking
whether a code refactor improved the benchmark scores.

## Tests
5 new test cases — all passing. Uses deterministic fixture data
so tests are not dependent on real benchmark files.

Closes #87 