### PR TITLE
Add docs/ tutorial directory with three guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ VIBEBENCH/
 │   ├── groq_generator.py    # Groq API code generator
 │   └── openai_generator.py  # OpenAI API code generator
 ├── datasets/            # Benchmark task definitions
+├── docs/
+│   ├── adding-a-model.md        # Tutorial: add a new generator
+│   ├── adding-a-task.md         # Tutorial: add a new task
+│   └── interpreting-results.md  # Guide: understand the metrics
 ├── figures/             # Architecture and leaderboard figures
 ├── tests/               # pytest test suite
 ├── vibebench.py         # Main entry point
@@ -166,6 +170,13 @@ To reproduce the findings from our v1.2.0 release:
    ```bash
    python vibebench.py benchmark --tasks datasets/prompts.json --verbose
 
+## Documentation
+
+| Guide | Description |
+| ------- | ------------- |
+| [Adding a Model](docs/adding-a-model.md) | Add a new LLM provider |
+| [Adding a Task](docs/adding-a-task.md) | Add a new benchmark task |
+| [Interpreting Results](docs/interpreting-results.md) | Read the metrics |
 
 ## Citation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# VibeBench Documentation
+
+| Guide | Description |
+| ------- | ------------- |
+| [Adding a Model](adding-a-model.md) | How to add a new LLM provider generator |
+| [Adding a Task](adding-a-task.md) | How to add a new benchmark task |
+| [Interpreting Results](interpreting-results.md) | What each metric means |
+
+For installation and quick start, see the main [README](../README.md).

--- a/docs/adding-a-model.md
+++ b/docs/adding-a-model.md
@@ -1,0 +1,156 @@
+# How to Add a New Model Generator to VibeBench
+
+This guide walks you through adding support for a new LLM provider
+so VibeBench can collect benchmark outputs from it automatically.
+
+## Overview
+
+Each model provider has a dedicated generator module in `core/`.
+The three existing generators follow an identical pattern:
+
+| File | Provider | API Key Variable |
+| ------ | ---------- | ----------------- |
+| `core/gemini_generator.py` | Google Gemini | `GEMINI_API_KEY` |
+| `core/groq_generator.py` | Groq (LLaMA) | `GROQ_API_KEY` |
+| `core/openai_generator.py` | OpenAI GPT-4o | `OPENAI_API_KEY` |
+
+Adding a new generator takes approximately 30 minutes and follows
+the same five-function structure every time.
+
+## Step 1 — Install the Provider SDK
+
+Add the provider's Python SDK to `requirements.txt` under the
+optional LLM Generator APIs section:
+
+--- LLM Generator APIs (optional) ---
+google-genai>=0.3.0
+groq>=0.4.0
+openai>=1.0.0
+your-provider-sdk>=1.0.0   # add this line
+
+Install it in your environment:
+
+```bash
+pip install your-provider-sdk
+```
+
+## Step 2 — Create the Generator File
+
+Create `core/your_provider_generator.py`. Copy the structure from
+`core/openai_generator.py` as your starting point — it is the
+most recently written and cleanest template.
+
+Your file must implement exactly these five functions:
+
+### `generate_code_your_provider(prompt, model_name)`
+
+Calls the provider API and returns raw Python code as a string.
+Strip any markdown code fences from the response before returning:
+
+```python
+import re
+
+code = re.sub(r'^```python\s*', '', code, flags=re.MULTILINE)
+code = re.sub(r'^```\s*', '', code, flags=re.MULTILINE)
+return code.strip()
+```
+
+### `load_tasks(tasks_file)`
+
+Reads `datasets/prompts.json` and returns a list of task dicts.
+This function is identical across all generators — copy it verbatim.
+
+### `save_generated_code(code, model_name, task_name, output_dir)`
+
+Saves the generated code to `datasets/<model_name>/<task_name>.py`.
+This function is also identical across all generators — copy it
+verbatim.
+
+### `run_generator(tasks_file, model_name, output_dir)`
+
+The main loop: loads tasks, calls `generate_code_your_provider()`
+for each, saves the output. Tracks success and failure counts.
+
+### `main()`
+
+Argument parsing with `argparse`. Must accept `--tasks`, `--model`,
+and `--output-dir` flags matching the other generators.
+
+## Step 3 — Add the API Key
+
+Open `.env.example` and add your provider's key:
+YOUR_PROVIDER_API_KEY=your_key_here
+
+Read the key from the environment in your generator:
+
+```python
+api_key = os.environ.get("YOUR_PROVIDER_API_KEY")
+if not api_key:
+    raise EnvironmentError(
+        "YOUR_PROVIDER_API_KEY environment variable is not set."
+    )
+```
+
+## Step 4 — Add the System Prompt
+
+Use the same system prompt as the other generators. Consistency
+in the system prompt is important — it means differences in output
+are attributable to the model, not to different instructions:
+
+```python
+system_prompt = (
+    "You are an expert Python developer. "
+    "Write a complete, working Python function for the following task. "
+    "Return ONLY the raw Python code with no markdown, no explanations, "
+    "and no code fences."
+)
+```
+
+## Step 5 — Write Tests
+
+Create `tests/test_your_provider_generator.py`. Use
+`tests/test_openai_generator.py` as your template. The key
+requirement is that tests must not make real API calls — use
+`unittest.mock.patch` to intercept the API client.
+
+Your test file must cover:
+
+- `load_tasks()` loads a valid file
+- `load_tasks()` raises `FileNotFoundError` on missing file
+- `save_generated_code()` creates the output file
+- `save_generated_code()` sanitises the model name in the path
+- `generate_code_your_provider()` raises `EnvironmentError`
+  without an API key
+- `generate_code_your_provider()` strips markdown fences
+
+## Step 6 — Run the Generator
+
+Set your API key and run:
+
+```bash
+export YOUR_PROVIDER_API_KEY=your_key_here
+python core/your_provider_generator.py --tasks datasets/prompts.json
+```
+
+Outputs are saved to `datasets/your_provider_model_name/`.
+
+## Step 7 — Run the Benchmark
+
+```bash
+vibebench benchmark --tasks datasets/prompts.json --export-csv
+```
+
+VibeBench automatically discovers the new model's outputs and
+includes them in the leaderboard.
+
+## Step 8 — Open a Pull Request
+
+Follow the standard contribution workflow:
+
+1. Create a branch: `git checkout -b feature/your-provider-generator`
+2. Commit your generator file and tests
+3. Open a PR referencing any related Issue
+4. Ensure all tests pass in CI before merging
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution
+guidelines.

--- a/docs/adding-a-task.md
+++ b/docs/adding-a-task.md
@@ -1,0 +1,175 @@
+# How to Add a New Benchmark Task to VibeBench
+
+This guide explains how to add a new coding task to the VibeBench
+benchmark suite, collect model outputs, and run the evaluation.
+
+## Overview
+
+Each benchmark task consists of:
+
+1. A task definition in `datasets/prompts.json`
+2. A human-authored baseline solution in `datasets/human_samples/`
+3. Model-generated solutions in `datasets/ai_samples/<model>/`
+
+## Step 1 — Define the Task in prompts.json
+
+Open `datasets/prompts.json` and add a new entry. Follow the
+existing schema exactly:
+
+```json
+{
+  "id": "TASK-011",
+  "category": "Data Structures",
+  "difficulty": "Easy",
+  "prompt": "Write a Python function that implements a stack with push, pop, and peek operations.",
+  "expected_complexity_limit": 3.0
+}
+```
+
+Fields:
+
+- `id` — Sequential task identifier. Use the next available number.
+- `category` — One of: Data Structures, Algorithms, Cybersecurity,
+  File I/O, Math/Logic. Add a new category if genuinely needed.
+- `difficulty` — One of: Easy, Medium, Hard.
+- `prompt` — The natural language instruction given to the model.
+  Keep it concise and unambiguous. Do not include examples or
+  starter code — models should generate everything from scratch.
+- `expected_complexity_limit` — The cyclomatic complexity above
+  which a solution is considered over-engineered for this task.
+
+## Step 2 — Write the Human Baseline Solution
+
+Create `datasets/human_samples/TASK-011_manual.py`. Write a clean,
+minimal solution that a competent developer would be satisfied with.
+
+Guidelines for baseline solutions:
+
+- Prioritise clarity over cleverness
+- Keep complexity low — the baseline sets the reference point
+- Make the `__main__` block self-contained (create any needed input
+  files, clean them up after)
+- Do not write docstrings unless they are genuinely necessary —
+  the human baseline intentionally has low docstring coverage to
+  reflect real-world practice
+
+Example baseline for a stack task:
+
+```python
+class Stack:
+    def __init__(self):
+        self._items = []
+
+    def push(self, item):
+        self._items.append(item)
+
+    def pop(self):
+        if not self._items:
+            raise IndexError("pop from empty stack")
+        return self._items.pop()
+
+    def peek(self):
+        if not self._items:
+            raise IndexError("peek at empty stack")
+        return self._items[-1]
+
+if __name__ == "__main__":
+    s = Stack()
+    s.push(1)
+    s.push(2)
+    print(s.peek())   # 2
+    print(s.pop())    # 2
+    print(s.pop())    # 1
+```
+
+## Step 3 — Verify the Baseline Runs
+
+```bash
+vibebench analyze --input datasets/human_samples/TASK-011_manual.py
+```
+
+Check the output. The baseline should:
+
+- Have no syntax errors (Halstead metrics must be a dict, not
+  "Syntax Error")
+- Execute without Runtime Error when run directly:
+  `python datasets/human_samples/TASK-011_manual.py`
+
+Fix any issues before collecting model outputs. A broken baseline
+causes incorrect Phi (Operational Parity) scores for all models
+on this task.
+
+## Step 4 — Collect Model Outputs
+
+For each model you want to evaluate, paste the prompt from Step 1
+into the model's interface and save the output. Follow these rules:
+
+- Use a fresh conversation — no prior context
+- Copy the code exactly as generated — do not edit it
+- Save to `datasets/ai_samples/<model>/TASK-011_<model>.py`
+
+File naming conventions:
+
+| Model | Filename |
+| ------- | ---------- |
+| ChatGPT | `TASK-011_chatgpt.py` |
+| Claude | `TASK-011_claude.py` |
+| Gemini | `TASK-011_ai.py` |
+| DeepSeek | `TASK-011_deepseek.py` |
+| Grok | `TASK-011_grok.py` |
+
+If using a generator script:
+
+```bash
+python core/openai_generator.py --tasks datasets/prompts.json --model gpt-4o
+```
+
+The generator will produce outputs for all tasks including the new
+one automatically.
+
+## Step 5 — Verify Each Model Output
+
+```bash
+vibebench analyze --input datasets/ai_samples/chatgpt/TASK-011_chatgpt.py
+```
+
+If `halstead_metrics` returns `"Syntax Error"`, the model generated
+invalid Python. Document this in `datasets/data_quality_notes.md`
+using the existing DQ-NNN format.
+
+## Step 6 — Run the Full Benchmark
+
+```bash
+vibebench benchmark --tasks datasets/prompts.json --export-csv --verbose
+```
+
+The new task will appear in the JSON report and leaderboard
+automatically — VibeBench discovers tasks by walking the datasets
+directory, not by reading prompts.json.
+
+## Step 7 — Update the Preprint or Documentation
+
+If you are contributing the new task to the public VibeBench
+repository, update:
+
+- `README.md` — update the task count in the benchmark description
+- `CHANGELOG.md` — add an entry under `[Unreleased]`
+- Open a Pull Request with the new task files and updated docs
+
+## Common Mistakes
+
+**Mistake: Baseline uses an external file that does not exist.**
+The executor runs the file in the VIBEBENCH root directory.
+If your baseline opens `data.csv`, that file must exist there,
+or the baseline must create it. See TASK-004 and TASK-008 for
+examples of self-contained baselines.
+
+**Mistake: Prompt is ambiguous about the expected interface.**
+"Write a sorting function" can be interpreted many ways.
+"Write a Python function `merge_sort(arr)` that takes an unsorted
+list and returns a new sorted list" produces more comparable
+outputs across models.
+
+**Mistake: Difficulty set too high, causing all models to fail.**
+If all models get Runtime Error, the task produces no useful
+comparative data. Start with Easy or Medium difficulty.

--- a/docs/interpreting-results.md
+++ b/docs/interpreting-results.md
@@ -1,0 +1,179 @@
+# How to Interpret VibeBench Results
+
+This guide explains what each metric in the VibeBench output means
+and how to read the leaderboard.
+
+## The JSON Output
+
+Each record in the benchmark JSON file represents one Python file
+evaluated by VibeBench:
+
+```json
+{
+  "schema_version": "1.1",
+  "model": "chatgpt",
+  "category": "AI Synthesis",
+  "file": "TASK-001_chatgpt.py",
+  "complexity": 1.8,
+  "docstring_coverage": 100.0,
+  "bad_practices_count": 0,
+  "execution_time_sec": 0.060,
+  "vibebench_score": 0.42,
+  "status": "Success",
+  "timestamp": "2026-05-08T19:30:00"
+}
+```
+
+## Metrics Explained
+
+### Cyclomatic Complexity (`complexity`)
+
+Measures the number of linearly independent paths through the code,
+computed using the `radon` library (McCabe 1976). Higher values
+indicate more branching and harder-to-test code.
+
+| Score | Interpretation |
+| ------- | --------------- |
+| 1–5 | Simple, low risk |
+| 6–10 | Moderate complexity |
+| 11–20 | High complexity — consider refactoring |
+| 21+ | Very high risk — hard to test and maintain |
+
+The human baseline average in VibeBench v1.3 is **3.55**. AI models
+typically score 10–22% higher than this baseline.
+
+### Docstring Coverage (`docstring_coverage`)
+
+Percentage of functions, async functions, and classes that include
+a docstring. Computed via AST inspection.
+
+- `100.0` — every function is documented
+- `0.0` — no functions have docstrings
+- `null` — the file has no functions or classes (script-only files)
+
+Note: Low docstring coverage is not necessarily bad for very short
+functions. It becomes a concern in files with 3+ non-trivial
+functions.
+
+### Bad Practices Count (`bad_practices_count`)
+
+Number of anti-patterns detected by VibeBench's heuristic engine.
+Each detected issue adds 1 to the count. Current heuristics:
+
+| Heuristic | Example |
+| ----------- | --------- |
+| Hardcoded credential | `api_key = "abc123xyz"` |
+| TODO/FIXME placeholder | `# TODO: insert logic here` |
+| Ghost comment | A line containing only `#` |
+| Duplicate import | `import os` appearing twice |
+| Mutable default argument | `def func(data=[]):` |
+
+A count of 0 means no issues were detected. Any count above 0
+should be investigated — even 1 mutable default argument can cause
+subtle bugs that are hard to trace.
+
+### Execution Time (`execution_time_sec`)
+
+Wall-clock time to execute the file in a sandboxed subprocess,
+measured in seconds. Includes import time.
+
+This metric has high variance because:
+
+- SSL tasks (TASK-002) involve network I/O and take 0.3–0.5s
+- Algorithm tasks take 0.03–0.06s
+
+Do not compare execution times across different task types.
+Compare only within the same task (e.g., all models on TASK-001).
+
+### VibeBench Score (`vibebench_score`)
+
+A composite metric combining complexity, documentation, and runtime
+efficiency into a single value. Lower is better.
+
+Formula: Σ = w₁·V̂ + w₂·M̂ + w₃·Φ
+
+Where:
+
+- V̂ = min-max normalised Halstead Volume
+- M̂ = min-max normalised Cyclomatic Complexity
+- Φ = T_baseline / T_llm (Operational Parity, capped at 2.0)
+- Default weights: w₁=0.4, w₂=0.4, w₃=0.2
+
+A score of 0.0 means perfect performance on all three dimensions.
+A score approaching 1.0 means high complexity, high Halstead
+volume, and slower than baseline execution.
+
+### Status (`status`)
+
+| Value | Meaning |
+| ------- | --------- |
+| `Success` | File ran and exited with code 0 |
+| `Runtime Error` | File ran but exited with non-zero code |
+| `Timeout` | File exceeded the 5-second CPU time limit |
+| `Error` | File could not be found or read |
+
+## The Leaderboard
+
+The leaderboard aggregates per-file metrics into per-model summaries.
+
+**Rank** is determined by success rate (descending), with average
+complexity as a tiebreaker. The human baseline is shown separately
+with a — rank because it is a reference point, not a competitor.
+
+**Reading the summary table:**
+
+| Rank | Model   | Avg Complexity | Avg Exec Time | Avg Doc Coverage | Bad Practices | Success Rate |
+| 1    | CHATGPT | 4.28           | 0.0851s       | 65.0%            | 0             | 9/10         |
+
+This row tells you: ChatGPT ranked first overall, produced solutions
+with average complexity 4.28 (higher than the human baseline of
+3.55), took 85ms average to execute, had docstrings in 65% of
+functions, had no bad practices detected, and succeeded on 9 of
+10 tasks.
+
+## The Significance Report
+
+The significance report answers: "Is this difference real, or could
+it be due to chance?"
+| Model A  | Model B | U Statistic | p-value | Significant |
+| CHATGPT  | CLAUDE  | 48.0        | 0.0312  | ✅ Yes      |
+| CHATGPT  | GEMINI  | 52.0        | 0.4821  | ❌ No       |
+
+A p-value below 0.05 means the difference between two models is
+statistically significant at the 95% confidence level. A p-value
+above 0.05 means the observed difference could plausibly be due
+to chance given the sample sizes.
+
+With only 10 tasks per model, statistical power is limited. Treat
+significant results as strong indicators and non-significant results
+as inconclusive rather than evidence of no difference.
+
+## The Comparison Report
+
+The comparison report shows how a model's performance changed
+between two benchmark runs:
+| Model   | Success A | Success B | Δ Success |
+| CHATGPT | 8/10      | 9/10      | +10%      |
+| CLAUDE  | 7/10      | 7/10      | —         |
+
+A positive Δ Success means the model improved. A negative Δ Success
+means it regressed. Use this when comparing benchmark results before
+and after adding new tasks, or when a model provider releases an
+updated version.
+
+## Common Misinterpretations
+
+**"Higher docstring coverage means better code."**
+Not always. A file with trivial one-line functions and 100%
+docstring coverage is not better than a file with complex logic
+and 0% coverage. Docstring coverage is one signal among several.
+
+**"Lower execution time means better code."**
+Not for correctness. Faster execution can mean a simpler algorithm
+(good) or a broken one that exits early (bad). Always read status
+alongside execution time.
+
+**"A Runtime Error means the model failed the task."**
+Sometimes. Runtime Errors on TASK-010 across all AI models were
+caused by a missing `aiohttp` dependency, not by incorrect logic.
+Always inspect the actual file when investigating a failure.


### PR DESCRIPTION
## What this adds

A docs/ directory with three tutorial files targeting external
researchers who want to use VibeBench for their own work.

## Files added

**docs/adding-a-model.md** — 8-step guide to adding a new LLM
provider generator. Covers the five-function structure, system
prompt consistency, mock testing, and PR workflow.

**docs/adding-a-task.md** — 7-step guide to adding a new benchmark
task. Covers prompts.json schema, baseline writing guidelines,
self-contained __main__ blocks, and common mistakes.

**docs/interpreting-results.md** — Reference guide explaining all
five metrics (complexity, docstring coverage, bad practices,
execution time, VibeBench Score), the leaderboard, the significance
report, and the comparison report. Includes a common
misinterpretations section.

**docs/README.md** — Index table.

## Why this matters for JOSS

The JOSS reviewer checklist explicitly asks: "Is there documentation
beyond the README?" These tutorials directly satisfy that criterion.

Closes #94 
Closes #84 